### PR TITLE
Minor version bump.

### DIFF
--- a/lib/drawille/version.rb
+++ b/lib/drawille/version.rb
@@ -1,3 +1,3 @@
 module Drawille
-  VERSION = "0.3.2"
+  VERSION = "0.3.3"
 end


### PR DESCRIPTION
Doing this so changes like removing `pry` show up when using `gem install drawille`.
